### PR TITLE
consent: a cross-tool instruction change is its own consent

### DIFF
--- a/Cockpit.qml
+++ b/Cockpit.qml
@@ -4897,7 +4897,7 @@ Item {
               width: parent.width
               textFormat: Text.PlainText
               renderType: Text.NativeRendering
-              text: "YOUR CLICK MAY · download pinned restic, Bun, gbrain, and Ollama artifacts; build gbrain; pull the pinned local embedding model; create a signing identity and empty corpus only when no owned brain exists; and install or restart user services."
+              text: "YOUR CLICK MAY · download pinned restic, Bun, gbrain, and Ollama artifacts; build gbrain; pull the pinned local embedding model; create a signing identity and empty corpus only when no owned brain exists; and install or restart user services. YOUR CLICK WILL NOT · change how any other tool behaves. The agent skill that gives Claude Code instructions about SIA, the SUPER+SHIFT+B keybinding, and MCP registration are each declined unless you opt into them by name on the command line; the installer prints how."
               wrapMode: Text.WordWrap
               color: Qt.alpha(root.fg, 0.72)
               font.family: root.fontFamily

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -386,6 +386,18 @@ generation, and manager-state checks make interference visible at observed
 boundaries and fail closed, but do not turn the daemon into a hostile same-user
 sandbox.
 
+**Nothing SIA installs changes another program's behaviour unless you ask for
+it by name.** Three integrations touch surfaces SIA does not own: the agent
+skill at `~/.claude/skills/sia/SKILL.md`, which Claude Code reads and follows
+as instructions; the optional `SUPER+SHIFT+B` Hyprland keybinding; and MCP
+client registration. Each is declined by default. The skill and the keybinding
+require `SIA_INSTALL_AGENT_SKILL=1` and `SIA_INSTALL_KEYBINDING=1` respectively
+at the install command line, and MCP registration is never performed at all —
+the installer only prints the exact command for you to run. The first-light
+gate states this before you press anything. A cross-tool instruction change is
+a different category of act from installing SIA's own services, and it is
+consented to separately.
+
 The daemon runs unsandboxed as your user (like any Omarchy plugin — read
 the code before installing). The QML surfaces render dynamic snapshot strings
 with `Text.PlainText`. Their ordinary process actions use fixed SIA command

--- a/install.sh
+++ b/install.sh
@@ -10078,6 +10078,23 @@ install_agent_skill() {
   local installed_marker skill_stage marker_stage rollback_archive
   local marker_rollback_archive owned_generations
   local retain_previous=0
+  # A cross-tool instruction change is its own consent, separate from
+  # installing SIA.  Everything else in this installer acts on SIA's own
+  # roots and services; this one writes a file that ANOTHER program reads as
+  # instructions and follows, and it persists after that program is next
+  # started.  The keybinding above already treats a change to the operator's
+  # desktop as opt-in, and the MCP step below only ever prints the exact
+  # command rather than registering anything.  This is the same class of act
+  # and gets the same treatment: declined by default, with the manual path
+  # printed so nothing is lost by declining.  Reported by HANCORE-linux on
+  # marketplace verify issue #4078.
+  if [ "${SIA_INSTALL_AGENT_SKILL:-0}" != "1" ]; then
+    echo "  agent skill not installed — it would write instructions that"
+    echo "  Claude Code reads and follows, at $SKILL_FILE"
+    echo "  set SIA_INSTALL_AGENT_SKILL=1 when running install.sh to consent,"
+    echo "  or copy it yourself from $SIA_ORIGINAL_REPO/skill/SKILL.md"
+    return 0
+  fi
   for candidate in "$HOME/.claude" "$HOME/.claude/skills" "$SKILL_DIR"; do
     if [ -L "$candidate" ]; then
       echo "  agent skill preserved: symbolic config path $candidate"

--- a/tests/test_marketplace_first_light.py
+++ b/tests/test_marketplace_first_light.py
@@ -950,3 +950,57 @@ process.stdout.write(String(context[process.argv[2]].apply(null, args)))
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CrossToolConsent(unittest.TestCase):
+    """Installing SIA must not change how another program behaves.
+
+    Reported by HANCORE-linux on marketplace verify issue #4078: the installer
+    wrote an agent skill under ``~/.claude/skills/sia`` — a file Claude Code
+    reads and follows as instructions, persisting after SIA's own step is
+    over — while the visible consent boundary enumerated five categories of
+    action and did not name that one. The installer already treated the
+    Hyprland keybinding as opt-in and refused to register MCP clients at all,
+    so the one surface that changed another tool's instructions was the one
+    surface with no separate consent.
+    """
+
+    def test_the_agent_skill_is_declined_unless_named_on_the_command_line(
+            self):
+        installer = _read("install.sh")
+        body = "install_agent_skill() {" + installer.split(
+            "install_agent_skill() {", 1)[1].split("\n}\n", 1)[0] + "\n}\n"
+        self.assertIn('"${SIA_INSTALL_AGENT_SKILL:-0}" != "1"', body)
+        # The gate must precede every write, so a default run cannot reach
+        # mkdir/stage/publish at all.
+        gate = body.index('SIA_INSTALL_AGENT_SKILL')
+        for writer in ('mkdir -p "$SKILL_DIR"', 'owned_file_cas'):
+            with self.subTest(writer=writer):
+                self.assertLess(gate, body.index(writer))
+
+    def test_declining_still_tells_you_how_to_do_it_yourself(self):
+        installer = _read("install.sh")
+        self.assertIn("agent skill not installed", installer)
+        self.assertIn("skill/SKILL.md", installer)
+
+    def test_every_cross_tool_surface_is_opt_in_or_advisory(self):
+        installer = _read("install.sh")
+        # keybinding: opt-in. skill: opt-in. MCP: printed, never executed.
+        self.assertIn('"${SIA_INSTALL_KEYBINDING:-0}" != "1"', installer)
+        self.assertIn('"${SIA_INSTALL_AGENT_SKILL:-0}" != "1"', installer)
+        self.assertNotRegex(
+            installer, r'(?m)^\s*claude mcp add\b',
+            "MCP registration must be printed for the operator, never run")
+
+    def test_the_consent_boundary_names_the_cross_tool_category(self):
+        cockpit = _read("Cockpit.qml")
+        self.assertIn("YOUR CLICK WILL NOT", cockpit)
+        self.assertIn("change how any other tool behaves", cockpit)
+        for surface in ("agent skill", "keybinding", "MCP registration"):
+            with self.subTest(surface=surface):
+                self.assertIn(surface, cockpit)
+
+    def test_the_security_note_states_the_same_boundary(self):
+        security = _read("SECURITY.md")
+        self.assertIn("SIA_INSTALL_AGENT_SKILL=1", security)
+        self.assertIn(".claude/skills/sia/SKILL.md", security)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -5251,7 +5251,8 @@ install_agent_skill
 ''')
             result = subprocess.run(
                 ["bash", "-c", script, "skill-install-race", skill_dir,
-                 release], env={**os.environ, "RACE_TARGET": skill},
+                 release], env={**os.environ, "RACE_TARGET": skill,
+                      "SIA_INSTALL_AGENT_SKILL": "1"},
                 text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 check=False)
             self.assertNotEqual(result.returncode, 0)
@@ -5284,6 +5285,7 @@ install_agent_skill
             result = subprocess.run(
                 ["bash", "-c", script, "skill-marker-race", skill_dir,
                  release], env={**os.environ, "RACE_MARKER": marker,
+                      "SIA_INSTALL_AGENT_SKILL": "1",
                                 "RACE_SKILL": skill}, text=True,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
             self.assertNotEqual(result.returncode, 0)
@@ -5305,7 +5307,8 @@ remove_managed_skill
 ''')
             result = subprocess.run(
                 ["bash", "-c", script, "skill-uninstall-race", skill_dir],
-                env={**os.environ, "RACE_TARGET": skill}, text=True,
+                env={**os.environ, "RACE_TARGET": skill,
+                      "SIA_INSTALL_AGENT_SKILL": "1"}, text=True,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
             self.assertNotEqual(result.returncode, 0)
             self.assertEqual(_read_path(skill), "concurrent writer\n")


### PR DESCRIPTION
Closes the marketplace-verification block raised by @HANCORE-linux on AnubisQuantumCipher/homebrew-marketplace#4078 at `df377022b218f2a827e8ac7171b290398a290d61`:

> `install.sh:10072-10210` automatically installs a persistent Claude skill under `~/.claude/skills/sia`, but the visible consent boundary does not disclose or separately opt in to that cross-tool instruction change.

The finding is correct, and it is sharper than it was stated.

### Why this one mattered more than the line count suggests

This installer already treats two surfaces it does not own as requiring separate consent:

| surface | prior treatment |
|---|---|
| Hyprland keybinding | declined unless `SIA_INSTALL_KEYBINDING=1` |
| MCP registration | never performed — the installer prints the command for the operator to run |
| **agent skill** | **installed unconditionally** |

The one surface with neither gate was the one that writes a file another program reads as *instructions* and follows, persisting after SIA's own step is over.

The visible boundary made it worse rather than merely omitting it. It enumerates five categories — download artifacts, build gbrain, pull the model, create a signing identity and corpus, install or restart user services — so a reader has every reason to read that list as the scope of what a click does. Writing to another tool's configuration was outside all five and named in none.

### What changed

- The agent skill is declined unless `SIA_INSTALL_AGENT_SKILL=1`, in the same shape the keybinding already uses. The gate precedes every write, so a default run cannot `mkdir`, stage, or publish anything under `~/.claude`.
- Declining prints the file it would have written, what that file does, and where to copy it from — nothing is lost by saying no.
- The first-light gate carries a second sentence: **YOUR CLICK WILL NOT** change how any other tool behaves — naming the skill, the keybinding, and MCP registration as each separately opt-in, and saying the installer prints how.
- `SECURITY.md` states the same boundary and the reason: a cross-tool instruction change is a different category of act from installing SIA's own services.

### Evidence

Five tests in `CrossToolConsent` (`tests/test_marketplace_first_light.py`), all five red at `df37702` and green here — including one that pins the gate ahead of every writer, and one that asserts no cross-tool surface is installed without being named on the command line.

One pre-existing concurrency test drove `install_agent_skill` directly and now has to consent to the install it exercises; its three scenarios pass `SIA_INSTALL_AGENT_SKILL=1` explicitly. That is the honest change — the behaviour it tests still exists, it is just no longer the default.

925 tests green; `shellcheck`, `bash -n`, `qmllint`, and whitespace clean.
